### PR TITLE
Adds CORS access to calorie app

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,11 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
 
 app.use('/', indexRouter);
 app.use('/api/v1/users', usersRouter);


### PR DESCRIPTION
- This is that CORS thing I mentioned earlier. Apparently it allows other browsers to make fetch calls to your app. I'm not able to access our data from the browser without these few lines. I'd already added them to the Recipe App this morning and it worked fine over there.